### PR TITLE
Draw paths for dynamic content

### DIFF
--- a/jquery.html-svg-connect.js
+++ b/jquery.html-svg-connect.js
@@ -227,17 +227,49 @@
           fn.apply(context, args);
         }
       };
-    }
+    },
+    
+    /*
+	 * Add paths object
+	 * e.g., paths = [{ start: "#red", end: "#green", stroke: "blue" },{ start: "#red", end: "#yellow", stroke: "blue" }];
+	 * Public method within the plugin's prototype:
+	 * $("#svgContainer").HTMLSVGconnect("addPaths", paths);
+	 */
+	addPaths: function (paths) {
+	
+		var connRef = this;
+		$.each(paths, function (i, ref) {
+			var loadedPath = connRef.connectSetup(paths[i]);
+			if (loadedPath) {
+				connRef.loadedPaths.push(loadedPath);
+			}
+		});
+	
+	}
   });
 
   // A really lightweight plugin wrapper around the constructor,
   // preventing against multiple instantiations
   $.fn[pluginName] = function (options) {
-    return this.each(function () {
-      if (!$.data(this, "plugin_" + pluginName)) {
-        $.data(this, "plugin_" + pluginName, new Plugin(this, options));
-      }
-    });
-  };
+		var args = arguments;
+		if (options === undefined || typeof options === 'object') {
+			// Creates a new plugin instance, for each selected element, and
+			// stores a reference within the element's data
+			return this.each(function() {
+				if (!$.data(this, 'plugin_' + pluginName)) {
+					$.data(this, 'plugin_' + pluginName, new Plugin(this, options));
+				}
+			});
+		} else if (typeof options === 'string' && options[0] !== '_' && options !== 'init') {
+			// Call a public plugin method (not starting with an underscore) for each 
+			// selected element.
+			return this.each(function() {
+				var instance = $.data(this, 'plugin_' + pluginName);
+				if (instance instanceof Plugin && typeof instance[options] === 'function') {
+					instance[options].apply(instance, Array.prototype.slice.call(args, 1));
+				}
+			});
+		}
+	};
 
 })(jQuery, window, document);


### PR DESCRIPTION
Allows user to draw paths after content is loaded dynamically by
calling a public function inside plugin.

$(“#svgContainer").HTMLSVGconnect("addPaths", paths);

where paths can be any number of paths like [{ start: "#red", end:
"#green", stroke: "blue" },{ start: "#red", end: "#yellow", stroke:
"blue" }]

Adapted from answer from ojlewis